### PR TITLE
CentOS動作確認での気づきを反映

### DIFF
--- a/src/bin/server
+++ b/src/bin/server
@@ -29,7 +29,8 @@ function start() {
   local _retcode=$?
 
   if [[ ${_retcode} -eq ${EXITCODE_SUCCESS} ]]; then
-    log.info_teelog "in-house-swagger-server started. (port=${SERVER_PORT}, pid=$(cat ${DIR_JETTY}/jetty/jetty.pid))"
+    log.info_teelog "in-house-swagger-server started. (port=${SERVER_PORT})"
+    ${DIR_JETTY}/bin/jetty.sh check | log.info_teelog
   else
     log.error_teelog "in-house-swagger-server start failed."
   fi

--- a/src/config/project.properties
+++ b/src/config/project.properties
@@ -16,7 +16,7 @@ DOWNLOAD_URL_EDITOR="https://github.com/suwa-sh/swagger-editor/files/1180366/loc
 DOWNLOAD_URL_UI="https://github.com/suwa-sh/swagger-ui/files/1180373/local-swagger-ui-3.0.21.tar.gz"
 
 # server port
-SERVER_PORT=8081
+SERVER_PORT=8080
 
 
 # jetty起動引数


### PR DESCRIPTION
1. 起動ポートのデフォルト設定変更
設定変更が効くか確認した時の 8081 のままになっていたので
一般的な 8080 に戻してみました。

1. PID表示方法の変更
とりあえず、ポートとPIDくらいが確認できれば良いかな 程度だったので
PIDだけ取得するより、jetty.sh の check結果を全部出してみました。
※複数APサーバに対応するときは表示項目を揃えた方が良さそうですが、一旦はjettyそのままで良いかなと思っています。
